### PR TITLE
fix(ci): Repara el despliegue web en Cloud Run

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -20,8 +20,8 @@ RUN pnpm --filter @adyela/web build
 # =====================
 # Stage 2: Runtime
 # =====================
-FROM nginx:1.27-alpine AS production
-
+# FROM nginx:1.27-alpine AS production
+FROM nginxinc/nginx-unprivileged:stable-alpine AS production
 # gettext para envsubst (si lo usas)
 RUN apk add --no-cache gettext
 


### PR DESCRIPTION
Este PR soluciona el problema de permisos de Nginx que impedía el arranque del contenedor en Cloud Run. Se ajustó el Dockerfile y el script de inicio para asegurar que Nginx pueda escribir su archivo PID.