### PR TITLE
fix(ci): Repara el despliegue web en Cloud Run

### DIFF
--- a/.github/docker/web-entrypoint.sh
+++ b/.github/docker/web-entrypoint.sh
@@ -1,25 +1,8 @@
 #!/bin/sh
 set -e
 
-echo "===== INICIANDO SCRIPT DE DIAGNÓSTICO ====="
-echo "Usuario actual: $(whoami)"
+# Renderizar la plantilla con el PORT
+envsubst '$PORT' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
 
-echo "\n--- Verificando la directiva 'pid' en /etc/nginx/nginx.conf ---"
-cat /etc/nginx/nginx.conf | grep 'pid ' || echo "Directiva 'pid' no encontrada."
-echo "----------------------------------------------------"
-
-echo "\n--- Verificando la directiva 'error_log' en /etc/nginx/nginx.conf ---"
-cat /etc/nginx/nginx.conf | grep 'error_log' || echo "Directiva 'error_log' no encontrada."
-echo "----------------------------------------------------"
-
-echo "\nINFO: Procesando plantilla de Nginx con el puerto PORT=${PORT}"
-envsubst '$PORT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
-
-echo "\n--- Verificando permisos y contenido del archivo de configuración ---"
-ls -l /etc/nginx/conf.d/default.conf
-echo "----------------------------------------------------"
-
-echo "\nINFO: Iniciando Nginx en modo de depuración..."
-# Inicia Nginx en primer plano, cambiando al usuario 'nginx'
-
-exec nginx -g "pid /tmp/nginx.pid; daemon off;"
+# En la imagen unprivileged el PID ya va a /tmp; basta con daemon off
+exec nginx -g "daemon off;"


### PR DESCRIPTION
Este PR soluciona el problema de permisos de Nginx que impedía el arranque del contenedor en Cloud Run. Se ajustó el Dockerfile y el script de inicio para asegurar que Nginx pueda escribir su archivo PID.